### PR TITLE
Refactor unique_file() to use pathlib

### DIFF
--- a/darkseid/utils.py
+++ b/darkseid/utils.py
@@ -2,7 +2,6 @@
 # Copyright 2012-2014 Anthony Beville
 # Copyright 2019 Brian Pepple
 
-import os
 import pathlib
 
 
@@ -57,11 +56,13 @@ def remove_articles(text):
 
 def unique_file(file_name):
     """Takes a filename and if one already exist with that name returns a new filename"""
-    counter = 1
-    # returns ('/path/file', '.ext')
-    file_name_parts = os.path.splitext(file_name)
+    counter = 0
+    path = pathlib.Path(file_name)
+
     while True:
-        if not os.path.lexists(file_name):
-            return file_name
-        file_name = file_name_parts[0] + " (" + str(counter) + ")" + file_name_parts[1]
+        if not path.exists():
+            return path
         counter += 1
+        path = pathlib.Path(path.parent).joinpath(
+            f"{path.stem} ({counter}){path.suffix}"
+        )

--- a/tests/test_darkseid_utils.py
+++ b/tests/test_darkseid_utils.py
@@ -1,4 +1,3 @@
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -37,9 +36,10 @@ class TestUtils(unittest.TestCase):
         new_file = self.tmp_file_1.name
         new_name = utils.unique_file(new_file)
         # Now let's create our expected result
-        result_split = os.path.splitext(self.tmp_file_1.name)
-        correct_result = result_split[0] + " (1)" + result_split[1]
-        self.assertEqual(new_name, correct_result)
+        path = Path(self.tmp_file_1.name)
+        result = Path(path.parent).joinpath(f"{path.stem} (1){path.suffix}")
+
+        self.assertEqual(new_name, result)
 
     def test_recursive_list_with_file(self):
         expected_result = []


### PR DESCRIPTION
Right now it takes a string and returns a PosixPath, but eventually it should take a PosixPath also.