### PR TITLE
CBR support

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -15,6 +15,14 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - uses: actions/checkout@master
+      - name: Install unrar
+        run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get -y install unrar
+          else
+            echo "$RUNNER_OS not supported"
+          fi
+        shell: bash
       - name: Setup Python
         uses: actions/setup-python@master
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Install unrar
         run: |
-          sudo apt-get -y install unrar
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            sudo apt-get -y install unrar
+         else
+              echo "$RUNNER_OS not supported"
+              exit 1
+         fi
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,6 +33,7 @@ jobs:
           else
             echo "$RUNNER_OS not supported"
           fi
+        shell: bash
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,10 +30,10 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get -y install unrar
-         else
-              echo "$RUNNER_OS not supported"
-              exit 1
-         fi
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -24,8 +24,13 @@ jobs:
       #----------------------------------------------
       #       check-out repo and set-up python
       #----------------------------------------------
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install unrar
+        run: |
+          sudo apt-get -y install unrar
+      - name: Setup python
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       #----------------------------------------------

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,6 @@ jobs:
             sudo apt-get -y install unrar
           else
             echo "$RUNNER_OS not supported"
-            exit 1
           fi
       - name: Setup python
         uses: actions/setup-python@v2

--- a/poetry.lock
+++ b/poetry.lock
@@ -711,6 +711,14 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "rarfile"
+version = "4.0"
+description = "RAR archive reader for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -1020,7 +1028,7 @@ docs = ["sphinx-rtd-theme", "sphinxcontrib-napoleon"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "1455eac6cfc24ea6f785ae27965b082564d213b89ccefad0aeaf706afffa30dc"
+content-hash = "a23a3628b96db3b2e22029b90b3ce9abb88f798c94c51c8affd716d9d628c96a"
 
 [metadata.files]
 alabaster = [
@@ -1895,6 +1903,10 @@ pyzstd = [
     {file = "pyzstd-0.15.2-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f45220443598b6567cb0072354f886f9fdc861f309a8a87d89ab86e59bbff833"},
     {file = "pyzstd-0.15.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:a5fff428ed8d055fbf22dbd06b2804b3f4d9d857c4be30c5e0ae9efd4b0573b2"},
     {file = "pyzstd-0.15.2.tar.gz", hash = "sha256:eda9d2874a8f3823eea882125f304620f592693b3af0101c484bfc75726c8c59"},
+]
+rarfile = [
+    {file = "rarfile-4.0-py3-none-any.whl", hash = "sha256:1094869119012f95c31a6f22cc3a9edbdca61861b805241116adbe2d737b68f8"},
+    {file = "rarfile-4.0.tar.gz", hash = "sha256:67548769229c5bda0827c1663dce3f54644f9dbfba4ae86d4da2b2afd3e602a1"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ multi_line_output = 3
 line_length = 95
 default_section = "THIRDPARTY"
 known_first_party = []
-known_third_party = ["PIL", "lxml", "natsort", "py7zr", "pytest"]
+known_third_party = ["PIL", "lxml", "natsort", "py7zr", "pytest", "rarfile"]
 
 [tool.poetry.urls]
 "Homepage" = "https://github.com/bpepple/darkseid"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ natsort = "^8.0.0"
 sphinx-rtd-theme = {version="^0.5.2", optional=true}
 sphinxcontrib-napoleon = {version="^0.7", optional=true}
 py7zr = "^0.18.3"
+rarfile = "^4.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.0"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ IMG_DIR = TEST_FILES_PATH / "Captain_Science_001"
 ARCHIVE_PATH = TEST_FILES_PATH / "Captain Science #001.cbz"
 CB7_PATH = TEST_FILES_PATH / "Captain Science #001.cb7"
 CI_XSD = TEST_FILES_PATH / "ComicInfo.xsd"
+RAR_PATH = TEST_FILES_PATH / "Captain Science #001-cix-cbi.cbr"
 
 
 @pytest.fixture(scope="session")
@@ -51,3 +52,8 @@ def fake_cb7() -> ComicArchive:
 @pytest.fixture(scope="session")
 def fake_cbz() -> ComicArchive:
     return ComicArchive(ARCHIVE_PATH)
+
+
+@pytest.fixture(scope="session")
+def fake_rar() -> ComicArchive:
+    return ComicArchive(RAR_PATH)

--- a/tests/test_darkseid_comicarchive.py
+++ b/tests/test_darkseid_comicarchive.py
@@ -196,6 +196,7 @@ def test_removing_metadata_on_comic_wo_metadata(fake_cbz: ComicArchive) -> None:
     assert fake_cbz.remove_metadata() is True
 
 
+@pytest.mark.skipif(sys.platform in ["win32"], reason="Skip Windows.")
 def test_cbz_get_random_page(fake_cbz: ComicArchive) -> None:
     """Test to set if a page from a comic archive can be retrieved"""
     page = fake_cbz.get_page(4)
@@ -211,6 +212,7 @@ def test_archive_metadata_from_filename(fake_cbz: ComicArchive) -> None:
     assert test_md.issue == "1"
 
 
+@pytest.mark.skipif(sys.platform in ["win32"], reason="Skip Windows.")
 def test_archive_apply_file_info_to_metadata(fake_cbz: ComicArchive) -> None:
     """Test to apply archive info to the generic metadata"""
     test_md = GenericMetadata()

--- a/tests/test_darkseid_comicarchive.py
+++ b/tests/test_darkseid_comicarchive.py
@@ -232,6 +232,8 @@ def test_archive_export_to_cb7(tmp_path, fake_cbz: ComicArchive) -> None:
 #######
 # CBR #
 #######
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_file_exists(fake_rar: ComicArchive) -> None:
     """Test function that determines if a file is a rar file"""
     assert fake_rar.is_zip() is False
@@ -239,11 +241,15 @@ def test_rar_file_exists(fake_rar: ComicArchive) -> None:
     assert fake_rar.is_rar() is True
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_is_writable(fake_rar: ComicArchive) -> None:
     """Test to determine if rar archive is writable"""
     assert fake_rar.is_writable() is False
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_read_metadata(fake_rar: ComicArchive) -> None:
     """Test to read a rar files metadata"""
     md = fake_rar.read_metadata()
@@ -253,6 +259,8 @@ def test_rar_read_metadata(fake_rar: ComicArchive) -> None:
     assert md.page_count == 36
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_metadata_from_filename(fake_rar: ComicArchive) -> None:
     """Test to get metadata from comic archives filename"""
     test_md = fake_rar.metadata_from_filename()
@@ -260,11 +268,15 @@ def test_rar_metadata_from_filename(fake_rar: ComicArchive) -> None:
     assert test_md.issue == "1"
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_number_of_pages(fake_rar: ComicArchive) -> None:
     """Test to determine number of pages in a comic archive"""
     assert fake_rar.get_number_of_pages() == 36
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_get_random_page(fake_rar: ComicArchive) -> None:
     """Test to set if a page from a comic archive can be retrieved"""
     page = fake_rar.get_page(4)
@@ -273,6 +285,8 @@ def test_rar_get_random_page(fake_rar: ComicArchive) -> None:
     assert image == page
 
 
+# Skip test for Windows and MacOS.
+@pytest.mark.skipif(sys.platform in ["win32", "darwin"], reason="Skip MacOS & Windows.")
 def test_rar_export_to_zip(tmp_path, fake_rar: ComicArchive) -> None:
     fn = tmp_path / "fake_export.cbz"
     assert fake_rar.export_as_zip(fn) is True

--- a/tests/test_darkseid_comicarchive.py
+++ b/tests/test_darkseid_comicarchive.py
@@ -229,6 +229,58 @@ def test_archive_export_to_cb7(tmp_path, fake_cbz: ComicArchive) -> None:
     assert ca.get_number_of_pages() == 5
 
 
+#######
+# CBR #
+#######
+def test_rar_file_exists(fake_rar: ComicArchive) -> None:
+    """Test function that determines if a file is a rar file"""
+    assert fake_rar.is_zip() is False
+    assert fake_rar.is_sevenzip() is False
+    assert fake_rar.is_rar() is True
+
+
+def test_rar_is_writable(fake_rar: ComicArchive) -> None:
+    """Test to determine if rar archive is writable"""
+    assert fake_rar.is_writable() is False
+
+
+def test_rar_read_metadata(fake_rar: ComicArchive) -> None:
+    """Test to read a rar files metadata"""
+    md = fake_rar.read_metadata()
+    assert md.series == "Captain Science"
+    assert md.issue == "1"
+    assert md.volume == 1950
+    assert md.page_count == 36
+
+
+def test_rar_metadata_from_filename(fake_rar: ComicArchive) -> None:
+    """Test to get metadata from comic archives filename"""
+    test_md = fake_rar.metadata_from_filename()
+    assert test_md.series == "Captain Science"
+    assert test_md.issue == "1"
+
+
+def test_rar_number_of_pages(fake_rar: ComicArchive) -> None:
+    """Test to determine number of pages in a comic archive"""
+    assert fake_rar.get_number_of_pages() == 36
+
+
+def test_rar_get_random_page(fake_rar: ComicArchive) -> None:
+    """Test to set if a page from a comic archive can be retrieved"""
+    page = fake_rar.get_page(4)
+    with open(PAGE_FIVE, "rb") as cif:
+        image = cif.read()
+    assert image == page
+
+
+def test_rar_export_to_zip(tmp_path, fake_rar: ComicArchive) -> None:
+    fn = tmp_path / "fake_export.cbz"
+    assert fake_rar.export_as_zip(fn) is True
+    ca = ComicArchive(fn)
+    assert ca.is_zip() is True
+    assert ca.get_number_of_pages() == 36
+
+
 ###########
 # Unknown #
 ###########


### PR DESCRIPTION
Addd support for cbr files. Changes include:

- Add copy_from_archive() method for ZipArchives, so cbr's can be exported to cbz.
- If unrar isn't available raise  RarCannotExec.