### PR TITLE
Move typing_extensions import in TYPE_CHECKING block

### DIFF
--- a/darkseid/archivers/sevenzip.py
+++ b/darkseid/archivers/sevenzip.py
@@ -52,12 +52,13 @@ except ImportError:
 
 from typing import TYPE_CHECKING
 
-from typing_extensions import Self
-
 from darkseid.archivers import Archiver, ArchiverReadError, ArchiverWriteError
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from typing_extensions import Self
+
 
 logger = logging.getLogger(__name__)
 

--- a/darkseid/archivers/tar.py
+++ b/darkseid/archivers/tar.py
@@ -43,12 +43,12 @@ import logging
 import tarfile
 from typing import TYPE_CHECKING
 
-from typing_extensions import Self
-
 from darkseid.archivers.archiver import Archiver, ArchiverReadError, ArchiverWriteError
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 

--- a/darkseid/archivers/zip.py
+++ b/darkseid/archivers/zip.py
@@ -25,13 +25,14 @@ from typing import TYPE_CHECKING
 from zipfile import is_zipfile
 
 import rarfile
-from typing_extensions import Self
 from zipremove import ZIP_DEFLATED, ZIP_STORED, BadZipfile, ZipFile
 
 from darkseid.archivers.archiver import Archiver, ArchiverReadError
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from typing_extensions import Self
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This PR fixes an import error that could cause installing the package to fail.