### PR TITLE
Instead of raising ValueError on GTIN length validation return None

### DIFF
--- a/darkseid/metadata/data_classes.py
+++ b/darkseid/metadata/data_classes.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
     from decimal import Decimal
 
 
+import logging
+
 import pycountry
+
+logger = logging.getLogger(__name__)
 
 # Constants
 MAX_UPC = 17
@@ -497,9 +501,6 @@ class GTIN(Validations):
         Returns:
             Optional[int]: The validated UPC value, or None if the value is None or not an instance of int.
 
-        Raises:
-            ValueError: Raised when the length of the UPC value is greater than the maximum allowed length.
-
         """
         # sourcery skip: class-extract-method
         if value is None or not isinstance(value, int):
@@ -507,8 +508,8 @@ class GTIN(Validations):
 
         int_str = str(value)
         if len(int_str) > MAX_UPC:
-            msg = f"UPC has a length greater than {MAX_UPC}"
-            raise ValueError(msg)
+            logger.warning("UPC has a length greater than %s", MAX_UPC)
+            return None
 
         return value
 
@@ -527,17 +528,14 @@ class GTIN(Validations):
         Returns:
             Optional[int]: The validated ISBN value, or None if the value is None or not an instance of int.
 
-        Raises:
-            ValueError: Raised when the length of the ISBN value is greater than the maximum allowed length.
-
         """
         if value is None or not isinstance(value, int):
             return None
 
         int_str = str(value)
         if len(int_str) > MAX_ISBN:
-            msg = f"ISBN has a length greater than {MAX_ISBN}"
-            raise ValueError(msg)
+            logger.warning("ISBN has a length greater than %s", MAX_ISBN)
+            return None
 
         return value
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -410,14 +410,16 @@ def test_gtin_string_values():
 
 def test_gtin_upc_invalid_values():
     """Test GTIN validation with invalid UPC."""
-    with pytest.raises(ValueError, match="UPC has a length greater than"):
-        GTIN(upc=1234567890123456789)
+    gtin = GTIN(upc=1234567890123456789)
+    assert gtin.upc is None
+    assert gtin.isbn is None
 
 
 def test_gtin_isbn_valid_values():
     """Test GTIN validation with ISBN."""
-    with pytest.raises(ValueError, match="ISBN has a length greater than"):
-        GTIN(isbn=1234567890123456789)
+    gtin = GTIN(isbn=1234567890123456789)
+    assert gtin.isbn is None
+    assert gtin.upc is None
 
 
 def test_price_none_country():


### PR DESCRIPTION
This PR fixes a bug when writing metadata and the GTIN fails validation. Instead of raising a ValueError we should just return `None` and not write the invalid data.