### PR TITLE
Add constants module for comic archive file extensions

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,42 +1,42 @@
-name-template: "v$RESOLVED_VERSION"
-tag-template: "v$RESOLVED_VERSION"
+name-template: v$RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
 categories:
-  - title: "🚀 Features"
+  - title: 🚀 Features
     labels:
-      - "feature"
-      - "enhancement"
-  - title: "🐛 Bug Fixes"
+      - feature
+      - enhancement
+  - title: 🐛 Bug Fixes
     labels:
-      - "bug"
-      - "bugfix"
-  - title: "🧰 Maintenance"
+      - bug
+      - bugfix
+  - title: 🧰 Maintenance
     labels:
-      - "improvements"
-      - "chore"
-      - "dependencies"
-      - "documentation"
-      - "github_actions"
+      - improvements
+      - chore
+      - dependencies
+      - documentation
+      - github_actions
 exclude-labels:
-  - "bot"
-  - "dependabot"
-  - "ci"
+  - bot
+  - dependabot
+  - ci
 version-resolver:
   major:
     labels:
-      - "major"
+      - major
   minor:
     labels:
-      - "feature"
-      - "enhancement"
+      - feature
+      - enhancement
   patch:
     labels:
-      - "bug"
-      - "bugfix"
-      - "improvements"
-      - "chore"
-      - "dependencies"
-      - "documentation"
-      - "github_actions"
+      - bug
+      - bugfix
+      - improvements
+      - chore
+      - dependencies
+      - documentation
+      - github_actions
   default: patch
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&'

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 .cache
 celerybeat.pid
 celerybeat-schedule
+CLAUDE.md
 *.cover
 .coverage
 .coverage.*
@@ -88,5 +89,3 @@ venv/
 venv.bak/
 .webassets-cache
 wheels/
-# Add any AI information files that should be ignored below
-CLAUDE.md

--- a/darkseid/archivers/factory.py
+++ b/darkseid/archivers/factory.py
@@ -39,6 +39,7 @@ from darkseid.archivers.rar import RarArchiver
 from darkseid.archivers.sevenzip import PY7ZR_AVAILABLE
 from darkseid.archivers.tar import TarArchiver
 from darkseid.archivers.zip import ZipArchiver
+from darkseid.constants import CB7, CBR, CBT, CBZ, PDF
 
 if PYMUPDF_AVAILABLE:
     from darkseid.archivers.pdf import PdfArchiver
@@ -241,17 +242,17 @@ class ArchiverFactory:
 
     # Build the archiver map with optional dependencies
     _ARCHIVER_MAP: ClassVar[dict[str, type[Archiver]]] = {
-        ".cbz": ZipArchiver,  # Comic book ZIP format
-        ".cbr": RarArchiver,  # Comic book RAR format
-        ".cbt": TarArchiver,  # Comic book TAR format
+        CBZ: ZipArchiver,
+        CBR: RarArchiver,
+        CBT: TarArchiver,
     }
 
     # Register optional archivers at class definition time
     if PYMUPDF_AVAILABLE:
-        _ARCHIVER_MAP[".pdf"] = PdfArchiver  # PDF document format
+        _ARCHIVER_MAP[PDF] = PdfArchiver
 
     if PY7ZR_AVAILABLE:
-        _ARCHIVER_MAP[".cb7"] = SevenZipArchiver  # 7Zip support
+        _ARCHIVER_MAP[CB7] = SevenZipArchiver
 
     @classmethod
     def create_archiver(cls, path: Path) -> Archiver:
@@ -397,13 +398,13 @@ class ArchiverFactory:
 
         """
         base_map = {
-            ".cbz": ZipArchiver,
-            ".cbr": RarArchiver,
-            ".cbt": TarArchiver,
+            CBZ: ZipArchiver,
+            CBR: RarArchiver,
+            CBT: TarArchiver,
         }
         # Add optional archivers if their dependencies are available
         if PYMUPDF_AVAILABLE:
-            base_map[".pdf"] = PdfArchiver
+            base_map[PDF] = PdfArchiver
         if PY7ZR_AVAILABLE:
-            base_map[".cb7"] = SevenZipArchiver
+            base_map[CB7] = SevenZipArchiver
         cls._ARCHIVER_MAP = base_map

--- a/darkseid/comic.py
+++ b/darkseid/comic.py
@@ -46,6 +46,7 @@ except ImportError:
 
 from darkseid.archivers import ArchiverFactory, ArchiverReadError
 from darkseid.archivers.zip import ZipArchiver
+from darkseid.constants import CBZ, PDF
 from darkseid.metadata.comicinfo import ComicInfo
 from darkseid.metadata.data_classes import ImageMetadata, Metadata
 from darkseid.metadata.metroninfo import MetronInfo
@@ -1188,7 +1189,7 @@ class Comic:
             return
 
         # Do not calculate page sizes for PDF files, as it can be very slow and resource-intensive.
-        if calc_page_sizes and self._path.suffix.lower() != ".pdf":
+        if calc_page_sizes and self._path.suffix.lower() != PDF:
             self._calculate_all_page_info(metadata)
 
     def _calculate_all_page_info(self, metadata: Metadata) -> None:
@@ -1273,7 +1274,7 @@ class Comic:
             Large archives may require significant time and disk space for conversion.
 
         """
-        if self._path.suffix.lower() == ".cbz":
+        if self._path.suffix.lower() == CBZ:
             logger.info("Archive %s is already in ZIP format", self._path)
             return True
 

--- a/darkseid/constants.py
+++ b/darkseid/constants.py
@@ -1,0 +1,9 @@
+"""Constants for comic archive file extensions."""
+
+from __future__ import annotations
+
+CB7 = ".cb7"
+CBR = ".cbr"
+CBT = ".cbt"
+CBZ = ".cbz"
+PDF = ".pdf"

--- a/darkseid/utils.py
+++ b/darkseid/utils.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from darkseid.archivers.pdf import PYMUPDF_AVAILABLE
 from darkseid.archivers.sevenzip import PY7ZR_AVAILABLE
+from darkseid.constants import CB7, CBR, CBT, CBZ, PDF
 
 
 # TODO: Change to StrEnum when Python-3.10 support dropped
@@ -107,11 +108,11 @@ def get_recursive_filelist(path_list: list[Path]) -> list[Path]:
         True
 
     """
-    comic_extensions = ["*.cbz", "*.cbr", "*.cbt"]
+    comic_extensions = [f"*{CBZ}", f"*{CBR}", f"*{CBT}"]
     if PY7ZR_AVAILABLE:
-        comic_extensions += ["*.cb7"]
+        comic_extensions += [f"*{CB7}"]
     if PYMUPDF_AVAILABLE:
-        comic_extensions += ["*.pdf"]
+        comic_extensions += [f"*{PDF}"]
     filelist: list[Path] = []
 
     for path_item in path_list:


### PR DESCRIPTION
## Summary

- Add `darkseid/constants.py` defining named constants for all supported comic archive extensions (`.cb7`, `.cbr`, `.cbt`, `.cbz`, `.pdf`)
- Replace hardcoded extension strings in `ArchiverFactory` (both `_ARCHIVER_MAP` and `clear_registry`) with the new constants
- Replace hardcoded extension strings in `Comic` (PDF page size check and CBZ format check) with the new constants
- Replace hardcoded glob patterns in `get_recursive_filelist` with patterns derived from the new constants
