### PR TITLE
Fix duplicate xmlns attributes and silent XML parse failures in MetronInfo/ComicInfo

### DIFF
--- a/darkseid/metadata/base_handler.py
+++ b/darkseid/metadata/base_handler.py
@@ -7,11 +7,12 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from defusedxml.ElementTree import parse
 
-from darkseid.metadata.data_classes import Metadata
+if TYPE_CHECKING:
+    from darkseid.metadata.data_classes import Metadata
 
 
 class XmlError(Exception):
@@ -100,11 +101,15 @@ class BaseMetadataHandler(ABC):
         Returns:
             The resulting Metadata object.
 
+        Raises:
+            XmlError: If the XML file cannot be parsed.
+
         """
         try:
             tree = parse(filename)
-        except ET.ParseError:
-            return Metadata()
+        except ET.ParseError as e:
+            msg = f"Failed to parse XML file '{filename}': {e!r}"
+            raise XmlError(msg) from e
         return self._convert_xml_to_metadata(tree)
 
     @staticmethod

--- a/darkseid/metadata/comicinfo.py
+++ b/darkseid/metadata/comicinfo.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, cast
 from defusedxml.ElementTree import fromstring
 
 from darkseid.issue_string import IssueString
-from darkseid.metadata.base_handler import BaseMetadataHandler
+from darkseid.metadata.base_handler import BaseMetadataHandler, XmlError
 from darkseid.metadata.data_classes import (
     AgeRatings,
     Arc,
@@ -230,11 +230,15 @@ class ComicInfo(BaseMetadataHandler):
         Returns:
             The parsed Metadata object.
 
+        Raises:
+            XmlError: If the XML string cannot be parsed.
+
         """
         try:
             tree = ET.ElementTree(fromstring(xml_string))
-        except ET.ParseError:
-            return Metadata()
+        except ET.ParseError as e:
+            msg = f"Failed to parse ComicInfo XML: {e!r}"
+            raise XmlError(msg) from e
         return self._convert_xml_to_metadata(tree)
 
     def string_from_metadata(

--- a/darkseid/metadata/metroninfo.py
+++ b/darkseid/metadata/metroninfo.py
@@ -174,11 +174,15 @@ class MetronInfo(BaseMetadataHandler):
         Returns:
             The resulting Metadata object.
 
+        Raises:
+            XmlError: If the XML string cannot be parsed.
+
         """
         try:
             tree = ET.ElementTree(fromstring(xml_string))
-        except ParseError:
-            return Metadata()
+        except ParseError as e:
+            msg = f"Failed to parse MetronInfo XML: {e!r}"
+            raise XmlError(msg) from e
         return self._convert_xml_to_metadata(tree)
 
     def string_from_metadata(self, metadata: Metadata, xml_bytes: bytes = b"") -> str:

--- a/darkseid/metadata/metroninfo.py
+++ b/darkseid/metadata/metroninfo.py
@@ -260,6 +260,19 @@ class MetronInfo(BaseMetadataHandler):
             except ParseError:
                 root = ET.Element("MetronInfo")
 
+        # ElementTree parses namespaced attributes (e.g. xsi:schemaLocation) from
+        # existing XML into Clark notation ("{uri}local") rather than preserving
+        # the original "xsi:schemaLocation" key. Left in place, the attribute
+        # below would be added as a second, differently-keyed attribute, and
+        # ET.tostring() would auto-generate its own xmlns declaration for the
+        # Clark-notation one, producing duplicate xmlns:xsi/xsi:schemaLocation
+        # attributes in the serialized XML. Strip any such existing attribute
+        # for the XSI namespace before re-adding the canonical one below.
+        xsi_ns = "http://www.w3.org/2001/XMLSchema-instance"
+        root.attrib = {
+            key: value for key, value in root.attrib.items() if not key.startswith(f"{{{xsi_ns}}}")
+        }
+
         root.attrib["xmlns:metroninfo"] = (
             "https://metron-project.github.io/docs/metroninfo/schemas/v1.0"
         )

--- a/tests/test_base_handler.py
+++ b/tests/test_base_handler.py
@@ -140,13 +140,10 @@ def test_read_xml_valid_file(handler, temp_xml_file):
     assert metadata.title == "Test Title"
 
 
-def test_read_xml_invalid_file_returns_empty_metadata(handler, invalid_xml_file):
-    """Test that reading an invalid XML file returns empty Metadata."""
-    metadata = handler.read_xml(invalid_xml_file)
-
-    assert isinstance(metadata, Metadata)
-    # Should return empty metadata when parse fails
-    assert not hasattr(metadata, "title") or metadata.title is None
+def test_read_xml_invalid_file_raises_xml_error(handler, invalid_xml_file):
+    """Test that reading an invalid XML file raises XmlError instead of silently swallowing it."""
+    with pytest.raises(XmlError):
+        handler.read_xml(invalid_xml_file)
 
 
 def test_read_xml_nonexistent_file(handler, tmp_path):

--- a/tests/test_metroninfo.py
+++ b/tests/test_metroninfo.py
@@ -153,6 +153,51 @@ def test_get_root_malformed_xml(metron_info):
     assert result.tag == "MetronInfo"
 
 
+def test_get_root_no_duplicate_namespace_attributes(metron_info):
+    """Regression test for #238.
+
+    Merging metadata into an existing MetronInfo.xml that already declares the
+    namespaces (as any file previously written by darkseid would) must not
+    produce duplicate xmlns:xsi/xsi:schemaLocation attributes, since ElementTree
+    parses xsi:schemaLocation into Clark notation rather than the original
+    "xsi:schemaLocation" attribute name.
+    """
+    existing_xml = b"""<?xml version="1.0" encoding="UTF-8"?>
+    <MetronInfo xmlns:metroninfo="https://metron-project.github.io/docs/metroninfo/schemas/v1.0"
+                xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="https://metron-project.github.io/docs/metroninfo/schemas/v1.0 https://raw.githubusercontent.com/Metron-Project/metroninfo/refs/heads/master/schema/v1.0/MetronInfo.xsd">
+        <Number>1</Number>
+    </MetronInfo>"""
+
+    root = metron_info._get_root(existing_xml)
+    serialized = ET.tostring(root, encoding="unicode")
+
+    assert serialized.count("xmlns:xsi=") == 1
+    assert serialized.count("xsi:schemaLocation=") == 1
+    assert serialized.count("xmlns:metroninfo=") == 1
+    assert serialized.count("xmlns:xsd=") == 1
+
+
+def test_string_from_metadata_merge_no_duplicate_namespace_attributes(
+    metron_info, complex_metadata
+):
+    """Regression test for #238.
+
+    Writing metadata a second time using bytes produced by a first write must
+    not introduce duplicate namespace declarations/attributes.
+    """
+    first_pass = metron_info.string_from_metadata(complex_metadata)
+    second_pass = metron_info.string_from_metadata(
+        complex_metadata, first_pass.encode("utf-8")
+    )
+
+    assert second_pass.count("xmlns:xsi=") == 1
+    assert second_pass.count("xsi:schemaLocation=") == 1
+    assert second_pass.count("xmlns:metroninfo=") == 1
+    assert second_pass.count("xmlns:xsd=") == 1
+
+
 # Enhanced info source validation tests
 @pytest.mark.parametrize(
     ("source", "expected", "description"),

--- a/tests/test_metroninfo.py
+++ b/tests/test_metroninfo.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from darkseid.metadata.base_handler import XmlError
 from darkseid.metadata.data_classes import (
     GTIN,
     AgeRatings,
@@ -188,9 +189,7 @@ def test_string_from_metadata_merge_no_duplicate_namespace_attributes(
     not introduce duplicate namespace declarations/attributes.
     """
     first_pass = metron_info.string_from_metadata(complex_metadata)
-    second_pass = metron_info.string_from_metadata(
-        complex_metadata, first_pass.encode("utf-8")
-    )
+    second_pass = metron_info.string_from_metadata(complex_metadata, first_pass.encode("utf-8"))
 
     assert second_pass.count("xmlns:xsi=") == 1
     assert second_pass.count("xsi:schemaLocation=") == 1
@@ -330,7 +329,7 @@ def test_metadata_from_string_with_unicode(metron_info):
 
 
 def test_metadata_from_string_malformed_xml(metron_info):
-    """Test parsing malformed XML."""
+    """Test parsing malformed XML raises XmlError instead of silently swallowing it."""
     malformed_xml = """
     <MetronInfo>
         <Series>
@@ -339,9 +338,8 @@ def test_metadata_from_string_malformed_xml(metron_info):
     </MetronInfo>
     """
 
-    # Should handle gracefully and return some metadata
-    result = metron_info.metadata_from_string(malformed_xml)
-    assert isinstance(result, Metadata)
+    with pytest.raises(XmlError):
+        metron_info.metadata_from_string(malformed_xml)
 
 
 def test_metadata_from_string_empty_elements(metron_info):
@@ -404,14 +402,13 @@ def test_read_xml_file_not_found(metron_info, tmp_path):
 
 
 def test_read_xml_invalid_xml_file(metron_info, tmp_path):
-    """Test reading file with invalid XML."""
+    """Test reading file with invalid XML raises XmlError instead of silently swallowing it."""
     invalid_xml_file = tmp_path / "invalid.xml"
     with Path.open(invalid_xml_file, "w") as f:
         f.write("This is not XML content")
 
-    # Should handle gracefully
-    result = metron_info.read_xml(invalid_xml_file)
-    assert isinstance(result, Metadata)
+    with pytest.raises(XmlError):
+        metron_info.read_xml(invalid_xml_file)
 
 
 def test_round_trip_xml_conversion(metron_info, complex_metadata, tmp_path):


### PR DESCRIPTION
## Summary
- Fix `MetronInfo._get_root()` producing invalid XML (duplicate `xmlns:xsi` and `xsi:schemaLocation` attributes) when merging metadata into an existing   MetronInfo.xml. ElementTree parses an existing `xsi:schemaLocation` attribute into Clark notation rather than its literal form, so re-adding the canonical attribute left both present, and `ET.tostring()` auto-generated a second `xmlns:xsi` declaration for the Clark-notation one.
- `metadata_from_string()` (MetronInfo/ComicInfo) and `BaseMetadataHandler.read_xml()` now raise `XmlError` on unparseable XML instead of silently swallowing the failure and returning an empty `Metadata()`, which hid real corruption from callers.

## Behavior change
Callers that invoke `MetronInfo.metadata_from_string()`, `ComicInfo.metadata_from_string()`, or `BaseMetadataHandler.read_xml()` **directly** with malformed XML will now see an `XmlError` raised instead of getting back an empty `Metadata()`. Code that doesn't wrap these calls in a `try/except` will need to handle this.

`Comic` users are unaffected: `Comic._parse_metadata()` already wraps these calls in `try/except Exception` and logs via `logger.exception(...)`, so `Comic.read_metadata()` continues to degrade gracefully to an empty `Metadata()` on parse failure — it now also logs a clearer error.

Fixes #238